### PR TITLE
Configurable greeting message

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,14 @@
 # go-greeter
-A greeter HTTP service written in Go
+
+A greeter HTTP service written in Go.
+
+## Configuration
+
+The following environment variables are required: `GREETER_PORT`, `GREETER_GREETING`.
+
+An example configuration:
+
+```
+GREETER_PORT=8080
+GREETER_GREETING="Hello there"
+```

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/jvrplmlmn/go-greeter
 
 go 1.14
+
+require github.com/kelseyhightower/envconfig v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/kelseyhightower/envconfig v1.4.0 h1:Im6hONhd3pLkfDFsbRgu68RDNkGF1r3dvMUtDTo2cv8=
+github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ func main() {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/healthz", HealthzHandler)
+	mux.HandleFunc("/greet", GreeterHandler)
 
 	httpServer := &http.Server{
 		Addr:    ":8080",
@@ -22,4 +23,8 @@ func main() {
 
 func HealthzHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("OK"))
+}
+
+func GreeterHandler(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte("Hello!"))
 }

--- a/main.go
+++ b/main.go
@@ -2,11 +2,24 @@ package main
 
 import (
 	"log"
+	"net"
 	"net/http"
+
+	"github.com/kelseyhightower/envconfig"
 )
+
+type Config struct {
+	Host string
+	Port string `required:"true"`
+}
 
 func main() {
 	log.Println("Starting greeter service ...")
+
+	var c Config
+	if err := envconfig.Process("greeter", &c); err != nil {
+		log.Fatalf("Failed to process config from environment variables: %s", err)
+	}
 
 	mux := http.NewServeMux()
 
@@ -14,7 +27,7 @@ func main() {
 	mux.HandleFunc("/greet", GreeterHandler)
 
 	httpServer := &http.Server{
-		Addr:    ":8080",
+		Addr:    net.JoinHostPort(c.Host, c.Port),
 		Handler: mux,
 	}
 

--- a/main.go
+++ b/main.go
@@ -11,6 +11,8 @@ import (
 type Config struct {
 	Host string
 	Port string `required:"true"`
+
+	Greeting string `required:"true"`
 }
 
 func main() {
@@ -21,10 +23,11 @@ func main() {
 		log.Fatalf("Failed to process config from environment variables: %s", err)
 	}
 
-	mux := http.NewServeMux()
+	greeter := NewGreeter(c.Greeting)
 
+	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", HealthzHandler)
-	mux.HandleFunc("/greet", GreeterHandler)
+	mux.HandleFunc("/greet", greeter.Handler)
 
 	httpServer := &http.Server{
 		Addr:    net.JoinHostPort(c.Host, c.Port),
@@ -38,6 +41,14 @@ func HealthzHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Write([]byte("OK"))
 }
 
-func GreeterHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Write([]byte("Hello!"))
+type Greeter struct {
+	message string
+}
+
+func NewGreeter(message string) *Greeter {
+	return &Greeter{message: message}
+}
+
+func (g *Greeter) Handler(w http.ResponseWriter, _ *http.Request) {
+	w.Write([]byte(g.message))
 }


### PR DESCRIPTION
This adds a new /greet endpoint that will return the configured greeting.

Additionally, this makes the host and port configurable.

Both the greeting message and the port are required.